### PR TITLE
fix: Change extruder count for post-H2D introduction

### DIFF
--- a/change_filament_commented.gcode
+++ b/change_filament_commented.gcode
@@ -1,6 +1,6 @@
 M620 S[next_extruder]A ; Everything between this and M621 is skipped if there is no AMS
 M204 S9000 ; Set starting acceleration
-{if toolchange_count > 1} ; toolchange_count increments each time there is a filament change
+{if toolchange_count >= 1} ; toolchange_count increments each time there is a filament change
 G17
 G2 Z{max_layer_z + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift
 {endif}

--- a/change_filament_noAMS.gcode
+++ b/change_filament_noAMS.gcode
@@ -1,5 +1,5 @@
 ; change filament without AMS g-code
-{if toolchange_count > 1}
+{if toolchange_count >= 1}
 M204 S9000 ; set starting acceleration
 G17 ; set CNC workspace plane
 G2 Z{max_layer_z + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift


### PR DESCRIPTION
The first filament swap gets skipped in versions of Bambustudio post the release of the H2D dual-extruder printer. (tested on `BambuStudio-02.01.00.59` and `BambuStudio-02.01.01.52`).

Inspecting the generated .gcode files shows that the `toolchange_count = 1` conditional does not get triggered on the first filament swap. Subsequent swaps use the edited gcode as intended.

Changing to `toolchange_count >= 1` results in the expected behaviour on all swaps.

This has been tested on my A1M:
- 5 layer print with a colour change midway through each of the 5 layers
- 5 layer print with a colour change for each layer (so each layer alternates)



See the discussion in [this issue](https://github.com/eukatree/Bambu_CustomGCode/issues/23) for further context and possible P1 series fixes.